### PR TITLE
The first cut of activity log (APIm analytics) reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "request": "^2.60.0",
     "serve-favicon": "^2.3.0",
     "strong-express-metrics": "^2.0.1",
-    "strongloop-license": "^1.4.0"
+    "strongloop-license": "^1.4.0",
+    "uuid": "^2.0.1"
   },
   "optionalDependencies": {
     "loopback-explorer": "^1.8.0",

--- a/server/apim/.gitignore
+++ b/server/apim/.gitignore
@@ -1,0 +1,2 @@
+*.pem
+config.js*

--- a/server/apim/README.md
+++ b/server/apim/README.md
@@ -1,0 +1,4 @@
+Configuration files for APIm analytics
+
+ - private-key.pem
+ - public-cert.pem

--- a/server/middleware.json
+++ b/server/middleware.json
@@ -4,7 +4,8 @@
     },
     "cors": {
     },
-    "strong-express-metrics": []
+    "strong-express-metrics": [],
+    "./middleware/activity-log": []
   },
   "initial": {
     "compression": {

--- a/server/middleware/activity-log/index.js
+++ b/server/middleware/activity-log/index.js
@@ -1,0 +1,142 @@
+/*
+ * Report API usage events to IBM APIm backend.
+ */
+'use strict';
+var debug = require('debug')('strong-gateway:activity-log');
+var fs = require('fs');
+var request = require('request');
+var qs = require('querystring');
+var url = require('url');
+var uuid = require('uuid');
+
+var REQUEST_HEADERS = {
+  'accept': '*/%'
+};
+
+module.exports = function createActivityLogMiddleware(options) {
+  debug('configuration', options);
+
+  var auth = options.connection.auth;
+  if (!auth) auth = options.connection.auth = {};
+
+  if (!auth.key && auth.keyFile) {
+    auth.key = fs.readFileSync(auth.keyFile);
+  }
+  if (!auth.cert && auth.certFile) {
+    auth.cert = fs.readFileSync(auth.certFile);
+  }
+
+  return function logActivity(req, res, next) {
+    if (!req.__start) {
+      req.__start = new Date();
+    }
+
+    if (!req.__clientAddress) {
+      // Save the client address, as it is not available in Node v0.10
+      // at the time when the response was sent
+      req.__clientAddress = req.ip || req.connection.remoteAddress;
+    }
+
+    res.on('finish', function() {
+      if (!res.durationInMs) {
+        res.durationInMs = new Date() - req.__start;
+      }
+
+      processActivity(req, res, options);
+    });
+    next();
+  };
+};
+
+function processActivity(req, res, config) {
+  var event = buildApiEvent(req, res, config);
+  publishApiEvent(event, config);
+}
+
+function buildApiEvent(request, response, config) {
+  var urlParts = url.parse(request.originalUrl || request.url);
+
+  // ?num=1&str=hello => [ { "num": "1" }, { "str": "hello" } ]
+  var query = qs.parse(urlParts.query);
+  var queryArray = Object.keys(query).map(function(k) {
+    var item = Object.create(null);
+    item[k] = query[k];
+    return item;
+  });
+
+  return {
+    requestMethod: request.method,
+    uriPath: urlParts.pathname,
+    queryString: queryArray,
+    transactionId: uuid.v4(),
+    statusCode: String(response.statusCode),
+    timeToServeRequest: response.duration,
+    source: request.__clientAddress,
+    datetime: request.__start.toISOString(),
+
+    // Everything below are dummy placeholders for now
+
+    // TODO(ritch) Get these values from the upcoming gateway context
+    orgId: config.orgId,
+    envId: config.envId,
+
+    // TODO(bajtos)
+    bytesSent: 0,
+    bytesReceived: 0,
+    remoteHost: '',
+    userAgent: '',
+    requestProtocol: 'http',
+
+    // TODO(ritchie) Needs the upcoming gateway context
+    apiVersion: '',
+    apiId: '',
+    resourceId: '',
+    apiUser: '',
+
+    // Needs integration with APIm config and additional req/res interceptors
+    responseBody: '',
+    requestBody: '',
+    responseHttpHeaders: [],
+    requestHttpHeaders: [],
+
+    // Optional (?)
+    debug: [],
+    planId: '',
+    logPolicy: '',
+  };
+}
+
+function publishApiEvent(event, config) {
+  var auth = config.connection.auth;
+  var requestOptions = {
+    url: config.connection.url,
+    agentOptions: {
+      key: auth.key,
+      cert: auth.cert,
+      passphrase: auth.passphrase,
+      rejectUnauthorized: auth.rejectUnauthorized,
+    },
+    headers: REQUEST_HEADERS,
+    body: [
+      {
+        create: {
+          _type: 'apievent',
+          _index: config.orgId
+        }
+      },
+      event,
+    ].map(JSON.stringify).join('\n') + '\n',
+  };
+
+  debug('Uploading to %s\n%s', requestOptions.url, requestOptions.body);
+  request.post(requestOptions, function(err, response/*, body*/) {
+    if (err) {
+      return debug('Cannot upload APIm events', err);
+    }
+    if (response.statusCode >= 400) {
+      return debug('Cannot upload APIm events: status code %s\n%s',
+                   response.statusCode, response.body);
+    }
+    debug('APIm event(s) uploaded.');
+  });
+}

--- a/server/policy-config.json
+++ b/server/policy-config.json
@@ -22,7 +22,7 @@
     {
       "name": "default-api-pipeline",
       "policyIds": [
-        "default-metrics-policy",
+        "default-activity-log-policy",
         "default-auth-policy",
         "default-rate-limiting-policy",
         "default-api-proxy-policy"
@@ -31,7 +31,7 @@
     {
       "name": "note-api-pipeline",
       "policyIds": [
-        "default-metrics-policy",
+        "default-activity-log-policy",
         "auth-note-policy",
         "auth-demo-policy",
         "default-rate-limiting-policy",
@@ -41,7 +41,7 @@
     {
       "name": "local-protected-resource-pipeline",
       "policyIds": [
-        "default-metrics-policy",
+        "default-activity-log-policy",
         "auth-demo-policy",
         "default-rate-limiting-policy",
         "local-protected-resource-proxy-policy"
@@ -50,9 +50,20 @@
   ],
   "policies": [
     {
-      "name": "default-metrics-policy",
-      "type": "metrics",
-      "phase": "initial:before"
+      "name": "default-activity-log-policy",
+      "type": "activityLog",
+      "phase": "initial:before",
+      "connection": {
+        "url": "https://host:port/x2020/v1/events/_bulk",
+        "auth": {
+          "keyFile": "server/apim/private-key.pem",
+          "certFile": "server/apim/public-cert.pem",
+          "passphrase": "******",
+          "rejectUnauthorized": false
+        }
+      },
+      "orgId": "apim-org-id",
+      "envId": "apim-env-id"
     },
     {
       "name": "default-auth-policy",

--- a/server/policy-middleware.js
+++ b/server/policy-middleware.js
@@ -56,9 +56,16 @@ function transpilePoliciesToMiddleware(policyConfig, options) {
       var entry = {
         params: middlewareEntry.params
       };
-      if (middlewareEntry.paths) {
-        entry.paths = middlewareEntry.paths;
+      var paths = middlewareEntry.paths;
+      if (paths) {
+        if (Array.isArray(paths)) {
+          paths = paths.map(fixMiddlewarePathType);
+        } else {
+          paths = fixMiddlewarePathType(paths);
+        }
+        entry.paths = paths;
       }
+
       if (Array.isArray(middlewareEntry.methods) &&
         middlewareEntry.methods.indexOf('all') === -1) {
         // Only add methods if it's not empty and not all
@@ -78,6 +85,11 @@ function transpilePoliciesToMiddleware(policyConfig, options) {
   }
   debug('Middleware for policies: %s', print(middleware));
   return middleware;
+}
+
+function fixMiddlewarePathType(value) {
+  return typeof value === 'string' && value[0] === '^' ?
+    new RegExp(value) : value;
 }
 
 function findPipeline(pipelines, id) {

--- a/server/policy-middleware.js
+++ b/server/policy-middleware.js
@@ -134,6 +134,7 @@ transpilePoliciesToMiddleware.policyToMiddlewareMapping = {
   proxy: proxyPolicyMapper,
   reverseProxy: proxyPolicyMapper,
   rateLimiting: './middleware/rate-limiting-policy',
+  activityLog: './middleware/activity-log',
   metrics: 'strong-express-metrics'
 };
 

--- a/test/activity-log-middleware.test.js
+++ b/test/activity-log-middleware.test.js
@@ -1,0 +1,159 @@
+var expect = require('chai').expect;
+var activityLog = require('../server/middleware/activity-log');
+var loopback= require('loopback');
+var supertest = require('supertest');
+
+var ORG_ID = 'an-org-id';
+var ENV_ID = 'an-env-id';
+
+describe('Activity Log middleware', function() {
+  var backendPort, eventsReported;
+  before(createBackendStub);
+
+  var app, request;
+  before(createTestAppAndRequest);
+
+  beforeEach(resetEnv);
+
+  it('pushes events to the configured URL', function(done) {
+    request.get('/api/products').expect(200, function(err) {
+      if (err) return done(err);
+      waitForBackend(function() {
+        expect(eventsReported).to.have.length(1);
+        done();
+      });
+    });
+  });
+
+  it('includes all expected fields', function(done) {
+    request.get('/api/products').expect(200, function(err) {
+      if (err) return done(err);
+      waitForBackend(function() {
+        expect(eventsReported).to.have.length(1);
+        var event = eventsReported[0];
+
+        // transactionId should be a UUID
+        expect(event.transactionId, 'transactionId').to.match(/^[-\da-z]+/);
+        delete event.transactionId;
+
+        expect(event.datetime, 'datetime').to.be.a('string');
+        expect(event.datetime, 'datetime').to.match(
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/); // ISO Date string
+
+        var ts = Date.parse(event.datetime);
+        if (isNaN(ts)) {
+          var msg = 'Timestamp ' + event.datetime + ' is not a valid date';
+          throw new Error(msg);
+        }
+        expect(Date.now() - ts).to.be.lessThan(2000);
+        delete event.datetime;
+
+        expect(eventsReported[0]).to.eql({
+          logPolicy: '',
+          planId: '',
+          requestHttpHeaders: [],
+          responseHttpHeaders: [],
+          requestBody: '',
+          responseBody: '',
+          apiUser: '',
+          resourceId: '',
+          apiId: '',
+          statusCode: '200',
+          queryString: [],
+          uriPath: '/api/products',
+          requestMethod: 'GET',
+          envId: ENV_ID,
+          orgId: ORG_ID,
+          debug: [],
+          source: '127.0.0.1',
+          bytesSent: 0,
+          bytesReceived: 0,
+          remoteHost: '',
+          userAgent: '',
+          requestProtocol: 'http',
+          apiVersion: ''
+        });
+        done();
+      });
+    });
+  });
+
+  it('parses query string', function(done) {
+    var url = '/api/products?filter[where][name]=red%20pencil';
+    request.get(url).expect(200, function(err) {
+      if (err) return done(err);
+      waitForBackend(function() {
+        expect(eventsReported).to.have.length(1);
+        var event = eventsReported[0];
+
+        expect(event.uriPath, 'uriPath').to.equal('/api/products');
+        expect(event.queryString, 'queryString').to.eql([
+          { 'filter[where][name]': 'red pencil' }
+        ]);
+        done();
+      });
+    });
+  });
+
+  // Wait few moments to let the backend process API events
+  function waitForBackend(next) {
+    wait();
+    function wait() {
+      if (eventsReported.length)
+        next();
+      else
+        setTimeout(wait, 10);
+    }
+  }
+
+  function createBackendStub(done) {
+    var app = loopback();
+    app.use(loopback.bodyParser.text({ type: function() { return true; } }));
+
+    app.post('/events/_bulk', function(req, res) {
+      // Move out of express' try/catch block so that any errors
+      // bubble up to mocha's global error handler
+      process.nextTick(function() {
+        var events = req.body.split('\n').filter(Boolean).map(JSON.parse);
+        var header = events.shift();
+        expect(header).to.eql({
+          create: { _type: 'apievent', _index: ORG_ID }
+        });
+        eventsReported = eventsReported.concat(events);
+        res.json({ ok: true });
+      });
+    });
+
+    app.listen(0, function() {
+      backendPort = this.address().port;
+      done();
+    });
+  }
+
+  function createTestAppAndRequest(done) {
+    app = loopback();
+    app.set('legacyExplorer', false);
+    app.dataSource('db', { connector: 'memory' });
+    var Product = loopback.createModel('Product');
+    app.model(Product, { dataSource: 'db' });
+
+    app.use('/api', activityLog({
+      connection: {
+        url: 'http://127.0.0.1:' + backendPort + '/events/_bulk',
+      },
+      orgId: ORG_ID,
+      envId: ENV_ID,
+    }));
+    app.use('/api', loopback.rest());
+    app.listen(0, '127.0.0.1', function() {
+      var port = this.address().port;
+      request = supertest('http://localhost:' + port);
+      done();
+    });
+  }
+
+  function resetEnv() {
+    eventsReported = [];
+  }
+});
+

--- a/test/policy-middleware.test.js
+++ b/test/policy-middleware.test.js
@@ -59,24 +59,27 @@ describe('policy to middleware transpilation', function() {
       var expectedResult = {
         'initial:before': {
           'strong-express-metrics': [{
-            paths: ['^/api/(.*)$', '^/protected/(.*)$', '/api/notes'],
+            paths: [/^\/api\/(.*)$/, /^\/protected\/(.*)$/, '/api/notes'],
             params: {}
           }]
         },
         auth: {
           'loopback-component-oauth2#authenticate': [{
-            paths: ['^/api/(.*)$'],
+            paths: [/^\/api\/(.*)$/],
             params: {scopes: []}
           },
-            {
-              paths: ['^/protected/(.*)$', '/api/notes'],
-              params: {scopes: ['demo']}
-            },
-            {paths: ['/api/notes'], params: {scopes: ['note', 'demo']}}]
+          {
+            paths: [/^\/protected\/(.*)$/, '/api/notes'],
+            params: {scopes: ['demo']}
+          },
+          {
+            paths: ['/api/notes'],
+            params: {scopes: ['note', 'demo']}
+          }]
         },
         'routes:after': {
           './middleware/rate-limiting-policy': [{
-            paths: ['^/api/(.*)$', '^/protected/(.*)$', '/api/notes'],
+            paths: [/^\/api\/(.*)$/, /^\/protected\/(.*)$/, '/api/notes'],
             params: {
               limit: 100,
               interval: 60000,
@@ -113,5 +116,4 @@ describe('policy to middleware transpilation', function() {
       expect(middleware).to.eql(expectedResult);
     })
   ;
-})
-;
+});

--- a/test/policy-middleware.test.js
+++ b/test/policy-middleware.test.js
@@ -58,9 +58,21 @@ describe('policy to middleware transpilation', function() {
       var middleware = transpilePoliciesToMiddleware(policyConfig);
       var expectedResult = {
         'initial:before': {
-          'strong-express-metrics': [{
+          './middleware/activity-log': [{
             paths: [/^\/api\/(.*)$/, /^\/protected\/(.*)$/, '/api/notes'],
-            params: {}
+            params: {
+              connection: {
+                auth: {
+                  certFile: 'server/apim/public-cert.pem',
+                  keyFile: 'server/apim/private-key.pem',
+                  passphrase: '******',
+                  rejectUnauthorized: false,
+                },
+                url: 'https://host:port/x2020/v1/events/_bulk',
+              },
+              envId: 'apim-env-id',
+              orgId: 'apim-org-id',
+            }
           }]
         },
         auth: {


### PR DESCRIPTION
The first commit fixes a bug in `server/policy-middleware.json` where paths entered as regexp-like strings were not converted before they were sent to express. As a result, some policies were never invoked, because  a path string like "^/api/(.*)$" never matches any request URL.

The second commit implements a new policy "activityLog" that reports API events to IBM APIm backend.

Example configuration:

```
{
  "name": "default-activity-log-policy",
  "type": "activityLog",
  "phase": "initial:before",
  "connection": {
    "url": "https://myhost:9443/x2020/v1/events/_bulk",
    "auth": {
      "keyFile": "server/apim/private-key.pem",
      "certFile": "server/apim/public-cert.pem",
      "passphrase": "****",
      "rejectUnauthorized": false
    }
  },
  "orgId": "some-org-id",
  "envId": "some-env-id"
}
```

Requires https://github.com/strongloop/loopback-boot/pull/159
Connect to strongloop-internal/scrum-loopback#556

/to @raymondfeng @ritch please review
